### PR TITLE
Sensor timestamp fix, tizen uses micro-seconds as timestamp unit. (#1…

### DIFF
--- a/cocos/platform/tizen/CCDevice-tizen.cpp
+++ b/cocos/platform/tizen/CCDevice-tizen.cpp
@@ -78,7 +78,7 @@ static void accelerometer_sensor_cb(sensor_h _sensor, sensor_event_s *sensor_dat
     _acceleration->x = sensor_data->values[0] / GRAVITY_EARTH;
     _acceleration->y = sensor_data->values[1] / GRAVITY_EARTH;
     _acceleration->z = sensor_data->values[2] / GRAVITY_EARTH;
-    _acceleration->timestamp = (double)sensor_data->timestamp / 1e3;
+    _acceleration->timestamp = (double)sensor_data->timestamp / 1e6;
 
     double tmp = _acceleration->x;
     Application *app = Application::getInstance();


### PR DESCRIPTION
merge from origin